### PR TITLE
Excluded .cf-before-edit files from being considered for editing in /…

### DIFF
--- a/sudo-requires-password.cf
+++ b/sudo-requires-password.cf
@@ -3,7 +3,7 @@ bundle agent sudo_requires_password
   meta:
     "tags" slist => { "autorun" };
   vars:
-    "sudoers_d_files" slist => lsdir("/etc/sudoers.d", "^(?!(\.$|\.\.$)).*", "true");
+    "sudoers_d_files" slist => lsdir("/etc/sudoers.d", "^(?!(\.$|\.\.$|.*\.cf-before-edit)).*", "true");
     "sudoers_files" slist  => {  "/etc/sudoers", @(sudoers_d_files) };
   files:
     "$(sudoers_files)"


### PR DESCRIPTION
…etc/sudoers.d

This change excludes .cf-before-edit suffixed files from being considered for editing. These files are created by CFEngine as a backup of the previous state. Editing these files results in an ever growing number of .cf-before-edit suffixed files being created and edited in /etc/sudoers.d